### PR TITLE
Fix duplicate listener registrations in useToast

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,8 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // Register listener only once on mount
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- stop registering toast state listener on every update

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493697e6fc8324b0427e5b336b2a1e