### PR TITLE
Remove leftover navigation comment

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -31,7 +31,6 @@ export function Navigation() {
       ))}
       <div className="ml-auto pl-4 md:ml-8">
         {" "}
-        {/* Added wrapper for toggle */}
         <ThemeToggle />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- delete obsolete toggle wrapper comment in `components/navigation.tsx`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68493b61f5f8832494010f7ec1a258e9