### PR TITLE
refactor sound cue selection

### DIFF
--- a/app/labs/lib/meditation-data.ts
+++ b/app/labs/lib/meditation-data.ts
@@ -564,33 +564,24 @@ export const NOTE_FREQUENCIES = {
   B5: 987.77,
 }
 
-// Musical meditation notes organized by category
+// Musical meditation notes grouped into pleasant octaves
 export const MUSICAL_NOTES = {
-  Metta: [
-    { id: "metta-c4", name: "C4", note: "C", octave: 4 },
-    { id: "metta-e4", name: "E4", note: "E", octave: 4 },
-    { id: "metta-g4", name: "G4", note: "G", octave: 4 },
-    { id: "metta-c5", name: "C5", note: "C", octave: 5 },
-  ],
-  Mindfulness: [
-    { id: "mind-a4", name: "A4", note: "A", octave: 4 },
-    { id: "mind-c5", name: "C5", note: "C", octave: 5 },
-    { id: "mind-d5", name: "D5", note: "D", octave: 5 },
-    { id: "mind-a4-return", name: "A4 (return)", note: "A", octave: 4 },
-  ],
-  Nonduality: [
-    { id: "non-g3", name: "G3", note: "G", octave: 3 },
-    { id: "non-d4", name: "D4", note: "D", octave: 4 },
-    { id: "non-g4", name: "G4", note: "G", octave: 4 },
-  ],
-  "Body Scan": [
-    { id: "body-g5", name: "G5", note: "G", octave: 5 },
-    { id: "body-f5", name: "F5", note: "F", octave: 5 },
-    { id: "body-e5", name: "E5", note: "E", octave: 5 },
-    { id: "body-d5", name: "D5", note: "D", octave: 5 },
-    { id: "body-c5", name: "C5", note: "C", octave: 5 },
-    { id: "body-b4", name: "B4", note: "B", octave: 4 },
-    { id: "body-a4", name: "A4", note: "A", octave: 4 },
+  Beautiful: [
+    { id: "note-c3", name: "C3", note: "C", octave: 3 },
+    { id: "note-d3", name: "D3", note: "D", octave: 3 },
+    { id: "note-e3", name: "E3", note: "E", octave: 3 },
+    { id: "note-g3", name: "G3", note: "G", octave: 3 },
+    { id: "note-a3", name: "A3", note: "A", octave: 3 },
+    { id: "note-c4", name: "C4", note: "C", octave: 4 },
+    { id: "note-d4", name: "D4", note: "D", octave: 4 },
+    { id: "note-e4", name: "E4", note: "E", octave: 4 },
+    { id: "note-g4", name: "G4", note: "G", octave: 4 },
+    { id: "note-a4", name: "A4", note: "A", octave: 4 },
+    { id: "note-c5", name: "C5", note: "C", octave: 5 },
+    { id: "note-d5", name: "D5", note: "D", octave: 5 },
+    { id: "note-e5", name: "E5", note: "E", octave: 5 },
+    { id: "note-g5", name: "G5", note: "G", octave: 5 },
+    { id: "note-a5", name: "A5", note: "A", octave: 5 },
   ],
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2114,57 +2114,100 @@ export default function HomePage() {
                       <div className="bg-gradient-to-r from-logo-teal-500 to-logo-emerald-500 py-3 px-6 dark:from-logo-teal-600 dark:to-logo-emerald-600 text-center">
                         <h3 className="text-white flex items-center font-black text-left">
                           <Music2 className="h-4 w-4 mr-2" />
-                          Musical Notes
+                          Sound Cues
                         </h3>
                       </div>
                       <div className="p-6 space-y-4 font-black">
-                        <Accordion type="single" collapsible className="w-full">
-                          {Object.entries(
-                            Object.entries(MUSICAL_NOTES).reduce(
-                              (acc, [category, notes]) => {
-                                notes.forEach((note) => {
-                                  const octave = `Octave ${note.octave}`
-                                  if (!acc[octave]) acc[octave] = []
-                                  acc[octave].push(note)
-                                })
-                                return acc
-                              },
-                              {} as Record<string, any[]>,
-                            ),
-                          ).map(([octave, notes]) => (
-                            <AccordionItem
-                              value={octave}
-                              key={octave}
-                              className="border-b border-gray-100 dark:border-gray-800"
-                            >
+                          <Accordion type="single" collapsible className="w-full">
+                            <AccordionItem value="musical-notes">
                               <AccordionTrigger className="text-logo-teal-500 dark:text-logo-teal-500 hover:no-underline py-3 font-serif font-black text-gray-600">
-                                {octave}
+                                Musical Notes
+                              </AccordionTrigger>
+                              <AccordionContent className="pb-4">
+                                <Accordion type="single" collapsible className="w-full">
+                                  {Object.entries(
+                                    Object.entries(MUSICAL_NOTES).reduce(
+                                      (acc, [_, notes]) => {
+                                        notes.forEach((note) => {
+                                          const octave = `Octave ${note.octave}`
+                                          if (!acc[octave]) acc[octave] = []
+                                          acc[octave].push(note)
+                                        })
+                                        return acc
+                                      },
+                                      {} as Record<string, any[]>,
+                                    ),
+                                  ).map(([octave, notes]) => (
+                                    <AccordionItem
+                                      value={octave}
+                                      key={octave}
+                                      className="border-b border-gray-100 dark:border-gray-800"
+                                    >
+                                      <AccordionTrigger className="text-logo-teal-500 dark:text-logo-teal-500 hover:no-underline py-3 font-serif font-black text-gray-600">
+                                        {octave}
+                                      </AccordionTrigger>
+                                      <AccordionContent className="pb-4">
+                                        <div className="space-y-2 text-gray-600">
+                                          {notes.map((note) => (
+                                            <div key={note.id} className="flex items-center gap-2 font-black font-serif">
+                                              <Button
+                                                variant={selectedSoundCue?.id === note.id ? "default" : "ghost"}
+                                                size="sm"
+                                                className={`flex-1 justify-start font-black font-serif text-gray-600 ${selectedSoundCue?.id === note.id ? "bg-white text-gray-600 border border-gray-600 hover:bg-gray-50 dark:bg-white dark:text-gray-600 dark:border-gray-600 dark:hover:bg-gray-50" : "hover:bg-gray-50 dark:hover:bg-gray-800"}`}
+                                                onClick={async () => {
+                                                  setSelectedSoundCue({
+                                                    id: note.id,
+                                                    name: note.name,
+                                                    src: `musical:${note.note}${note.octave}`,
+                                                  })
+                                                  await playNote(note.note, note.octave)
+                                                }}
+                                              >
+                                                {note.name}
+                                              </Button>
+                                              <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={async () => await playNote(note.note, note.octave)}
+                                                className="hover:bg-logo-emerald-50 dark:hover:bg-logo-emerald-900"
+                                                title={`Preview ${note.name}`}
+                                              >
+                                                <Play className="h-4 w-4" />
+                                              </Button>
+                                            </div>
+                                          ))}
+                                        </div>
+                                      </AccordionContent>
+                                    </AccordionItem>
+                                  ))}
+                                </Accordion>
+                              </AccordionContent>
+                            </AccordionItem>
+                            <AccordionItem value="miscellaneous">
+                              <AccordionTrigger className="text-logo-teal-500 dark:text-logo-teal-500 hover:no-underline py-3 font-serif font-black text-gray-600">
+                                Miscellaneous
                               </AccordionTrigger>
                               <AccordionContent className="pb-4">
                                 <div className="space-y-2 text-gray-600">
-                                  {notes.map((note) => (
-                                    <div key={note.id} className="flex items-center gap-2 font-black font-serif">
+                                  {SOUND_CUES_LIBRARY.map((cue) => (
+                                    <div key={cue.id} className="flex items-center gap-2 font-black font-serif">
                                       <Button
-                                        variant={selectedSoundCue?.id === note.id ? "default" : "ghost"}
+                                        variant={selectedSoundCue?.id === cue.id ? "default" : "ghost"}
                                         size="sm"
-                                        className={`flex-1 justify-start font-black font-serif text-gray-600 ${selectedSoundCue?.id === note.id ? "bg-white text-gray-600 border border-gray-600 hover:bg-gray-50 dark:bg-white dark:text-gray-600 dark:border-gray-600 dark:hover:bg-gray-50" : "hover:bg-gray-50 dark:hover:bg-gray-800"}`}
+                                        className={`flex-1 justify-start font-black font-serif text-gray-600 ${selectedSoundCue?.id === cue.id ? "bg-white text-gray-600 border border-gray-600 hover:bg-gray-50 dark:bg-white dark:text-gray-600 dark:border-gray-600 dark:hover:bg-gray-50" : "hover:bg-gray-50 dark:hover:bg-gray-800"}`}
                                         onClick={async () => {
-                                          setSelectedSoundCue({
-                                            id: note.id,
-                                            name: note.name,
-                                            src: `musical:${note.note}${note.octave}`,
-                                          })
-                                          await playNote(note.note, note.octave)
+                                          setSelectedSoundCue({ id: cue.id, name: cue.name, src: cue.src })
+                                          await playLabsSound(cue.src)
                                         }}
                                       >
-                                        {note.name}
+                                        {cue.name}
                                       </Button>
                                       <Button
                                         variant="ghost"
                                         size="sm"
-                                        onClick={async () => await playNote(note.note, note.octave)}
+                                        onClick={async () => await playLabsSound(cue.src)}
                                         className="hover:bg-logo-emerald-50 dark:hover:bg-logo-emerald-900"
-                                        title={`Preview ${note.name}`}
+                                        title={`Preview ${cue.name}`}
                                       >
                                         <Play className="h-4 w-4" />
                                       </Button>
@@ -2173,8 +2216,7 @@ export default function HomePage() {
                                 </div>
                               </AccordionContent>
                             </AccordionItem>
-                          ))}
-                        </Accordion>
+                          </Accordion>
                         <Button
                           className="w-full bg-white text-logo-teal-500 border border-logo-teal-500 hover:bg-gray-50 dark:bg-gray-900 dark:text-logo-teal-500 dark:border-logo-teal-500 dark:hover:bg-gray-800 font-serif font-black text-gray-600"
                           onClick={handleAddInstructionSoundEvent}

--- a/lib/meditation-data.ts
+++ b/lib/meditation-data.ts
@@ -527,33 +527,24 @@ export const NOTE_FREQUENCIES = {
   B5: 987.77,
 }
 
-// Musical meditation notes organized by category
+// Musical meditation notes grouped into pleasant octaves
 export const MUSICAL_NOTES = {
-  Metta: [
-    { id: "metta-c4", name: "C4", note: "C", octave: 4 },
-    { id: "metta-e4", name: "E4", note: "E", octave: 4 },
-    { id: "metta-g4", name: "G4", note: "G", octave: 4 },
-    { id: "metta-c5", name: "C5", note: "C", octave: 5 },
-  ],
-  Mindfulness: [
-    { id: "mind-a4", name: "A4", note: "A", octave: 4 },
-    { id: "mind-c5", name: "C5", note: "C", octave: 5 },
-    { id: "mind-d5", name: "D5", note: "D", octave: 5 },
-    { id: "mind-a4-return", name: "A4 (return)", note: "A", octave: 4 },
-  ],
-  Nonduality: [
-    { id: "non-g3", name: "G3", note: "G", octave: 3 },
-    { id: "non-d4", name: "D4", note: "D", octave: 4 },
-    { id: "non-g4", name: "G4", note: "G", octave: 4 },
-  ],
-  "Body Scan": [
-    { id: "body-g5", name: "G5", note: "G", octave: 5 },
-    { id: "body-f5", name: "F5", note: "F", octave: 5 },
-    { id: "body-e5", name: "E5", note: "E", octave: 5 },
-    { id: "body-d5", name: "D5", note: "D", octave: 5 },
-    { id: "body-c5", name: "C5", note: "C", octave: 5 },
-    { id: "body-b4", name: "B4", note: "B", octave: 4 },
-    { id: "body-a4", name: "A4", note: "A", octave: 4 },
+  Beautiful: [
+    { id: "note-c3", name: "C3", note: "C", octave: 3 },
+    { id: "note-d3", name: "D3", note: "D", octave: 3 },
+    { id: "note-e3", name: "E3", note: "E", octave: 3 },
+    { id: "note-g3", name: "G3", note: "G", octave: 3 },
+    { id: "note-a3", name: "A3", note: "A", octave: 3 },
+    { id: "note-c4", name: "C4", note: "C", octave: 4 },
+    { id: "note-d4", name: "D4", note: "D", octave: 4 },
+    { id: "note-e4", name: "E4", note: "E", octave: 4 },
+    { id: "note-g4", name: "G4", note: "G", octave: 4 },
+    { id: "note-a4", name: "A4", note: "A", octave: 4 },
+    { id: "note-c5", name: "C5", note: "C", octave: 5 },
+    { id: "note-d5", name: "D5", note: "D", octave: 5 },
+    { id: "note-e5", name: "E5", note: "E", octave: 5 },
+    { id: "note-g5", name: "G5", note: "G", octave: 5 },
+    { id: "note-a5", name: "A5", note: "A", octave: 5 },
   ],
 }
 


### PR DESCRIPTION
## Summary
- rename Musical Notes panel to Sound Cues and split into Musical Notes and Miscellaneous dropdowns
- curate pleasant note set across octaves for musical cues
- mirror note set in labs data for consistency

## Testing
- `pnpm lint` *(fails: next lint command missing node_modules)*
- `pnpm install` *(fails: web-speech-api package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68927a0679108324bddb2343cc4accd6