### PR TITLE
Enrich meditation sound cues with note-based synthesis

### DIFF
--- a/app/labs/lib/meditation-data.ts
+++ b/app/labs/lib/meditation-data.ts
@@ -1,18 +1,4 @@
-import type { Instruction as ImportedInstruction, SoundCue as ImportedSoundCue } from "./types"
-import type { AmbientSound } from "./types"
-
-export interface Instruction extends ImportedInstruction {
-  // Additional properties can be added here if needed
-}
-
-export interface SoundCue extends ImportedSoundCue {
-  frequency?: number
-  duration?: number
-  waveform?: string
-  harmonics?: number[]
-  attackDuration?: number
-  releaseDuration?: number
-}
+import type { Instruction, SoundCue, AmbientSound } from "../../lib/types"
 
 export const INSTRUCTIONS_LIBRARY: Instruction[] = [
   // Metta (Loving Kindness) Instructions
@@ -440,53 +426,73 @@ export const SOUND_CUES_LIBRARY: SoundCue[] = [
     id: "singing_bowl",
     name: "Singing Bowl",
     src: "synthetic:singing_bowl",
-    frequency: 432,
-    duration: 2500, // Total sound length in ms
+    note: "A4",
+    duration: 4000,
     waveform: "sine",
-    harmonics: [864, 1296, 1728], // More harmonics for richness
-    attackDuration: 0.1, // 100ms attack
-    releaseDuration: 2.0, // 2000ms release
+    harmonics: [
+      { ratio: 2, amplitude: 0.4, decay: 3.0 },
+      { ratio: 3, amplitude: 0.25, decay: 2.7 },
+      { ratio: 4.2, amplitude: 0.15, decay: 2.4 },
+    ],
+    attackDuration: 0.05,
+    releaseDuration: 3.0,
   },
   {
     id: "gentle_chime",
     name: "Gentle Chime",
     src: "synthetic:chime_gentle",
-    frequency: 1200, // Higher pitch
-    duration: 700, // Total sound length in ms
-    waveform: "triangle", // Softer than square, sharper than sine
-    attackDuration: 0.01, // 10ms attack
-    releaseDuration: 0.5, // 500ms release
+    note: "E6",
+    duration: 1000,
+    waveform: "triangle",
+    harmonics: [
+      { ratio: 2, amplitude: 0.5, decay: 0.7 },
+      { ratio: 3, amplitude: 0.3, decay: 0.6 },
+      { ratio: 4.1, amplitude: 0.15, decay: 0.5 },
+    ],
+    attackDuration: 0.01,
+    releaseDuration: 0.8,
   },
   {
     id: "soft_gong",
     name: "Soft Gong",
     src: "synthetic:soft_gong",
-    frequency: 180, // Lower, deeper tone
-    duration: 3000, // Total sound length in ms
+    note: "F3",
+    duration: 4500,
     waveform: "sine",
-    harmonics: [360, 540, 720], // For depth
-    attackDuration: 0.2, // 200ms attack
-    releaseDuration: 2.5, // 2500ms release
+    harmonics: [
+      { ratio: 1.5, amplitude: 0.5, decay: 3.5 },
+      { ratio: 2, amplitude: 0.3, decay: 3.0 },
+      { ratio: 2.7, amplitude: 0.2, decay: 2.6 },
+    ],
+    attackDuration: 0.3,
+    releaseDuration: 3.5,
   },
   {
     id: "short_bell",
     name: "Short Bell",
     src: "synthetic:short_bell",
-    frequency: 1500, // High, clear ring
-    duration: 500, // Total sound length in ms
-    waveform: "square", // Sharper, more metallic
-    attackDuration: 0.005, // 5ms attack
-    releaseDuration: 0.2, // 200ms release
+    note: "G6",
+    duration: 600,
+    waveform: "square",
+    harmonics: [
+      { ratio: 2, amplitude: 0.6, decay: 0.25 },
+      { ratio: 3, amplitude: 0.3, decay: 0.2 },
+      { ratio: 4.5, amplitude: 0.1, decay: 0.15 },
+    ],
+    attackDuration: 0.005,
+    releaseDuration: 0.3,
   },
   {
     id: "clear_tone",
     name: "Clear Tone",
     src: "synthetic:clear_tone",
-    frequency: 528,
-    duration: 1500, // Total sound length in ms
+    note: "C5",
+    duration: 1500,
     waveform: "sine",
-    attackDuration: 0.05, // 50ms attack
-    releaseDuration: 1.0, // 1000ms release
+    harmonics: [{ ratio: 2, amplitude: 0.2, decay: 1.1 }],
+    fm: { modRatio: 2, modIndex: 3 },
+    attackDuration: 0.02,
+    releaseDuration: 1.2,
   },
 ]
 
@@ -562,6 +568,13 @@ export const NOTE_FREQUENCIES = {
   G5: 783.99,
   A5: 880.0,
   B5: 987.77,
+  C6: 1046.5,
+  D6: 1174.66,
+  E6: 1318.51,
+  F6: 1396.91,
+  G6: 1567.98,
+  A6: 1760.0,
+  B6: 1975.53,
 }
 
 // Musical meditation notes grouped into pleasant octaves
@@ -597,7 +610,11 @@ export async function generateSyntheticSound(
     }
 
     const totalSoundDurationSeconds = (soundCue.duration || 1000) / 1000 // Convert to seconds
-    const frequency = soundCue.frequency || 440
+    const frequency =
+      soundCue.frequency ||
+      (soundCue.note
+        ? NOTE_FREQUENCIES[soundCue.note as keyof typeof NOTE_FREQUENCIES]
+        : 440)
     const waveform = soundCue.waveform || "sine"
     const attackDuration = soundCue.attackDuration || 0.01 // Default 10ms
     const releaseDuration = soundCue.releaseDuration || 0.5 // Default 500ms
@@ -605,6 +622,23 @@ export async function generateSyntheticSound(
     // Create oscillator
     const oscillator = audioContext.createOscillator()
     const gainNode = audioContext.createGain()
+
+    // FM synthesis support
+    if (soundCue.fm) {
+      const modOsc = audioContext.createOscillator()
+      const modGain = audioContext.createGain()
+      modOsc.frequency.setValueAtTime(
+        frequency * soundCue.fm.modRatio,
+        audioContext.currentTime,
+      )
+      modGain.gain.setValueAtTime(
+        soundCue.fm.modIndex * frequency,
+        audioContext.currentTime,
+      )
+      modOsc.connect(modGain).connect(oscillator.frequency)
+      modOsc.start()
+      modOsc.stop(audioContext.currentTime + totalSoundDurationSeconds)
+    }
 
     // Connect nodes
     oscillator.connect(gainNode)
@@ -644,7 +678,7 @@ export async function generateSyntheticSound(
 
     // Add harmonics if specified
     if (soundCue.harmonics) {
-      soundCue.harmonics.forEach((harmonic, index) => {
+      soundCue.harmonics.forEach((h) => {
         const harmonicOsc = audioContext.createOscillator()
         const harmonicGain = audioContext.createGain()
 
@@ -652,26 +686,22 @@ export async function generateSyntheticSound(
         harmonicGain.connect(audioContext.destination)
 
         harmonicOsc.type = waveform
-        harmonicOsc.frequency.setValueAtTime(harmonic, audioContext.currentTime)
+        harmonicOsc.frequency.setValueAtTime(
+          frequency * h.ratio,
+          audioContext.currentTime,
+        )
 
-        // Harmonics are quieter and follow a similar envelope
-        const harmonicVolume = (peakVolume * 0.2) / (index + 1) // Reduce volume for higher harmonics
+        const harmonicVolume = peakVolume * h.amplitude
 
         harmonicGain.gain.setValueAtTime(0, now)
-        harmonicGain.gain.linearRampToValueAtTime(harmonicVolume, now + attackDuration)
-
-        if (releaseStart > sustainStart) {
-          harmonicGain.gain.linearRampToValueAtTime(harmonicVolume, releaseStart)
-        } else {
-          harmonicGain.gain.linearRampToValueAtTime(
-            harmonicVolume,
-            Math.max(now + attackDuration, now + totalSoundDurationSeconds - releaseDuration),
-          )
-        }
-        harmonicGain.gain.exponentialRampToValueAtTime(endVolume, now + totalSoundDurationSeconds)
+        harmonicGain.gain.linearRampToValueAtTime(
+          harmonicVolume,
+          now + attackDuration,
+        )
+        harmonicGain.gain.exponentialRampToValueAtTime(endVolume, now + h.decay)
 
         harmonicOsc.start(now)
-        harmonicOsc.stop(now + totalSoundDurationSeconds)
+        harmonicOsc.stop(now + h.decay)
       })
     }
 

--- a/lib/meditation-data.ts
+++ b/lib/meditation-data.ts
@@ -410,53 +410,73 @@ export const SOUND_CUES_LIBRARY: SoundCue[] = [
     id: "singing_bowl",
     name: "Singing Bowl",
     src: "synthetic:singing_bowl",
-    frequency: 432,
-    duration: 2500, // Total sound length in ms
+    note: "A4",
+    duration: 4000,
     waveform: "sine",
-    harmonics: [864, 1296, 1728], // More harmonics for richness
-    attackDuration: 0.1, // 100ms attack
-    releaseDuration: 2.0, // 2000ms release
+    harmonics: [
+      { ratio: 2, amplitude: 0.4, decay: 3.0 },
+      { ratio: 3, amplitude: 0.25, decay: 2.7 },
+      { ratio: 4.2, amplitude: 0.15, decay: 2.4 },
+    ],
+    attackDuration: 0.05,
+    releaseDuration: 3.0,
   },
   {
     id: "gentle_chime",
     name: "Gentle Chime",
     src: "synthetic:chime_gentle",
-    frequency: 1200, // Higher pitch
-    duration: 700, // Total sound length in ms
-    waveform: "triangle", // Softer than square, sharper than sine
-    attackDuration: 0.01, // 10ms attack
-    releaseDuration: 0.5, // 500ms release
+    note: "E6",
+    duration: 1000,
+    waveform: "triangle",
+    harmonics: [
+      { ratio: 2, amplitude: 0.5, decay: 0.7 },
+      { ratio: 3, amplitude: 0.3, decay: 0.6 },
+      { ratio: 4.1, amplitude: 0.15, decay: 0.5 },
+    ],
+    attackDuration: 0.01,
+    releaseDuration: 0.8,
   },
   {
     id: "soft_gong",
     name: "Soft Gong",
     src: "synthetic:soft_gong",
-    frequency: 180, // Lower, deeper tone
-    duration: 3000, // Total sound length in ms
+    note: "F3",
+    duration: 4500,
     waveform: "sine",
-    harmonics: [360, 540, 720], // For depth
-    attackDuration: 0.2, // 200ms attack
-    releaseDuration: 2.5, // 2500ms release
+    harmonics: [
+      { ratio: 1.5, amplitude: 0.5, decay: 3.5 },
+      { ratio: 2, amplitude: 0.3, decay: 3.0 },
+      { ratio: 2.7, amplitude: 0.2, decay: 2.6 },
+    ],
+    attackDuration: 0.3,
+    releaseDuration: 3.5,
   },
   {
     id: "short_bell",
     name: "Short Bell",
     src: "synthetic:short_bell",
-    frequency: 1500, // High, clear ring
-    duration: 500, // Total sound length in ms
-    waveform: "square", // Sharper, more metallic
-    attackDuration: 0.005, // 5ms attack
-    releaseDuration: 0.2, // 200ms release
+    note: "G6",
+    duration: 600,
+    waveform: "square",
+    harmonics: [
+      { ratio: 2, amplitude: 0.6, decay: 0.25 },
+      { ratio: 3, amplitude: 0.3, decay: 0.2 },
+      { ratio: 4.5, amplitude: 0.1, decay: 0.15 },
+    ],
+    attackDuration: 0.005,
+    releaseDuration: 0.3,
   },
   {
     id: "clear_tone",
     name: "Clear Tone",
     src: "synthetic:clear_tone",
-    frequency: 528,
-    duration: 1500, // Total sound length in ms
+    note: "C5",
+    duration: 1500,
     waveform: "sine",
-    attackDuration: 0.05, // 50ms attack
-    releaseDuration: 1.0, // 1000ms release
+    harmonics: [{ ratio: 2, amplitude: 0.2, decay: 1.1 }],
+    fm: { modRatio: 2, modIndex: 3 },
+    attackDuration: 0.02,
+    releaseDuration: 1.2,
   },
 ]
 
@@ -525,6 +545,13 @@ export const NOTE_FREQUENCIES = {
   G5: 783.99,
   A5: 880.0,
   B5: 987.77,
+  C6: 1046.5,
+  D6: 1174.66,
+  E6: 1318.51,
+  F6: 1396.91,
+  G6: 1567.98,
+  A6: 1760.0,
+  B6: 1975.53,
 }
 
 // Musical meditation notes grouped into pleasant octaves
@@ -560,7 +587,11 @@ export async function generateSyntheticSound(
     }
 
     const totalSoundDurationSeconds = (soundCue.duration || 1000) / 1000 // Convert to seconds
-    const frequency = soundCue.frequency || 440
+    const frequency =
+      soundCue.frequency ||
+      (soundCue.note
+        ? NOTE_FREQUENCIES[soundCue.note as keyof typeof NOTE_FREQUENCIES]
+        : 440)
     const waveform = soundCue.waveform || "sine"
     const attackDuration = soundCue.attackDuration || 0.01 // Default 10ms
     const releaseDuration = soundCue.releaseDuration || 0.5 // Default 500ms
@@ -568,6 +599,23 @@ export async function generateSyntheticSound(
     // Create oscillator
     const oscillator = audioContext.createOscillator()
     const gainNode = audioContext.createGain()
+
+    // FM synthesis support
+    if (soundCue.fm) {
+      const modOsc = audioContext.createOscillator()
+      const modGain = audioContext.createGain()
+      modOsc.frequency.setValueAtTime(
+        frequency * soundCue.fm.modRatio,
+        audioContext.currentTime,
+      )
+      modGain.gain.setValueAtTime(
+        soundCue.fm.modIndex * frequency,
+        audioContext.currentTime,
+      )
+      modOsc.connect(modGain).connect(oscillator.frequency)
+      modOsc.start()
+      modOsc.stop(audioContext.currentTime + totalSoundDurationSeconds)
+    }
 
     // Connect nodes
     oscillator.connect(gainNode)
@@ -607,7 +655,7 @@ export async function generateSyntheticSound(
 
     // Add harmonics if specified
     if (soundCue.harmonics) {
-      soundCue.harmonics.forEach((harmonic, index) => {
+      soundCue.harmonics.forEach((h) => {
         const harmonicOsc = audioContext.createOscillator()
         const harmonicGain = audioContext.createGain()
 
@@ -615,26 +663,22 @@ export async function generateSyntheticSound(
         harmonicGain.connect(audioContext.destination) // Connect to the provided audioContext's destination
 
         harmonicOsc.type = waveform
-        harmonicOsc.frequency.setValueAtTime(harmonic, audioContext.currentTime)
+        harmonicOsc.frequency.setValueAtTime(
+          frequency * h.ratio,
+          audioContext.currentTime,
+        )
 
-        // Harmonics are quieter and follow a similar envelope
-        const harmonicVolume = (peakVolume * 0.2) / (index + 1) // Reduce volume for higher harmonics
+        const harmonicVolume = peakVolume * h.amplitude
 
         harmonicGain.gain.setValueAtTime(0, now)
-        harmonicGain.gain.linearRampToValueAtTime(harmonicVolume, now + attackDuration)
-
-        if (releaseStart > sustainStart) {
-          harmonicGain.gain.linearRampToValueAtTime(harmonicVolume, releaseStart)
-        } else {
-          harmonicGain.gain.linearRampToValueAtTime(
-            harmonicVolume,
-            Math.max(now + attackDuration, now + totalSoundDurationSeconds - releaseDuration),
-          )
-        }
-        harmonicGain.gain.exponentialRampToValueAtTime(endVolume, now + totalSoundDurationSeconds)
+        harmonicGain.gain.linearRampToValueAtTime(
+          harmonicVolume,
+          now + attackDuration,
+        )
+        harmonicGain.gain.exponentialRampToValueAtTime(endVolume, now + h.decay)
 
         harmonicOsc.start(now)
-        harmonicOsc.stop(now + totalSoundDurationSeconds)
+        harmonicOsc.stop(now + h.decay)
       })
     }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -8,10 +8,12 @@ export interface SoundCue {
   id: string
   name: string
   src: string // Path to audio file or synthetic: prefix
+  note?: string
   frequency?: number
   duration?: number // in milliseconds (total sound length)
   waveform?: OscillatorType
-  harmonics?: number[]
+  harmonics?: { ratio: number; amplitude: number; decay: number }[]
+  fm?: { modRatio: number; modIndex: number }
   attackDuration?: number // in seconds
   releaseDuration?: number // in seconds
 }


### PR DESCRIPTION
## Summary
- reference musical note constants for synthetic sound cues
- model instrument timbres with harmonic envelopes and FM support
- extend note frequency table and typings for richer synthesis

## Testing
- `pnpm install` (fails: GET https://registry.npmjs.org/web-speech-api: Not Found)
- `pnpm lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc3f70cd48324b5b8f11a707c2242