### PR TITLE
Adjust sound cue spacing to align with timeline

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2961,6 +2961,7 @@ none mb-4 py-0 px-0"
                             </AccordionContent>
                           </AccordionItem>
                         </Accordion>
+                        <div className="h-10" />
                         <Button
                           className="w-full bg-transparent text-gray-600 border-2 border-gray-500 hover:bg-gray-50 dark:bg-transparent dark:text-logo-rose-400 dark:border-logo-rose-400 dark:hover:bg-gray-800 font-serif font-black mt-auto"
                           onClick={handleAddInstructionSoundEvent}


### PR DESCRIPTION
## Summary
- add vertical spacing before Sound Cues' Add to Timeline button for better alignment with timeline

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2e0a18e083249e427e216012d00f