### PR TITLE
Align sound cues Add to Timeline button with misc section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2961,9 +2961,8 @@ none mb-4 py-0 px-0"
                             </AccordionContent>
                           </AccordionItem>
                         </Accordion>
-                        <div className="h-10" />
                         <Button
-                          className="w-full bg-transparent text-gray-600 border-2 border-gray-500 hover:bg-gray-50 dark:bg-transparent dark:text-logo-rose-400 dark:border-logo-rose-400 dark:hover:bg-gray-800 font-serif font-black mt-auto"
+                          className="w-full bg-transparent text-gray-600 border-2 border-gray-500 hover:bg-gray-50 dark:bg-transparent dark:text-logo-rose-400 dark:border-logo-rose-400 dark:hover:bg-gray-800 font-serif font-black"
                           onClick={handleAddInstructionSoundEvent}
                           disabled={!customInstructionText.trim() || !selectedSoundCue}
                         >


### PR DESCRIPTION
## Summary
- Tighten layout spacing in Sound Cues panel by removing extra spacer and auto margin before the Add to Timeline button

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ad51f3ea288324955623c766623cf1